### PR TITLE
FIX: wrong argument for Inductive.up in inductive_at_level

### DIFF
--- a/ocaml/core/gamma.ml
+++ b/ocaml/core/gamma.ml
@@ -227,8 +227,7 @@ let inductive_at_level (level: int) (c: t): Inductive.t option =
     match (Sequence.elem level c.entries).definition with
     | Inductive_type (i, _) ->
        let cnt0, ind = Sequence.elem i c.inductives in
-       let ntypes = Inductive.count_types ind in
-        Some (Inductive.up (count c - cnt0 - ntypes) ind)
+        Some (Inductive.up (count c - cnt0) ind)
 
     | _ ->
         None

--- a/ocaml/core/gamma.ml
+++ b/ocaml/core/gamma.ml
@@ -226,8 +226,9 @@ let add_inductive (ind: Inductive.t) (c: t): t =
 let inductive_at_level (level: int) (c: t): Inductive.t option =
     match (Sequence.elem level c.entries).definition with
     | Inductive_type (i, _) ->
-        let cnt0, ind = Sequence.elem i c.inductives in
-        Some (Inductive.up (count c - cnt0) ind)
+       let cnt0, ind = Sequence.elem i c.inductives in
+       let ntypes = Inductive.count_types ind in
+        Some (Inductive.up (count c - cnt0 - ntypes) ind)
 
     | _ ->
         None

--- a/ocaml/core/inductive.ml
+++ b/ocaml/core/inductive.ml
@@ -229,6 +229,7 @@ let constructor (i: int) (j: int) (ind: t): string * Term.typ =
     in
     let typ = push_params ntypes ind.params typ in
     name,
-    Term.up
+    Term.up_from
+        ntypes
         ind.n_up
         typ


### PR DESCRIPTION
I think the argument to `Inductive.up` in the function `inductive_at_level` in `Gamma` is wrong.

Explanation:
- the constructor types are valid in a context with all types of the family and the parameters (see comment line 114 in inductive.ml)
- the parameters don't go into the context in `add_inductive`
- hence, only the constructors (and everything pushed into the context afterwards) are "new"
- this means, we have to additionally subtract the number of types in the inductive family