### PR TITLE
Documentation for term shifting functions in Term

### DIFF
--- a/ocaml/core/term.ml
+++ b/ocaml/core/term.ml
@@ -576,6 +576,7 @@ let map (f: int -> int) (t: t): t =
 
 
 let up_from (start: int) (delta: int) (t:t): t =
+    assert (0 <= delta);
     map
         (fun i ->
             if start <= i then
@@ -586,7 +587,6 @@ let up_from (start: int) (delta: int) (t:t): t =
 
 
 let up (delta: int) (t: t): t =
-    assert (0 <= delta);
     if delta = 0 then
         t
     else

--- a/ocaml/core/term.mli
+++ b/ocaml/core/term.mli
@@ -184,13 +184,14 @@ val map: (int -> int) -> t -> t
 
 
 
-(** [up_from delta start t] *)
+(** [up_from delta start t]: increases all free variables >= [start] in [t] by [delta] *)
 val up_from: int -> int -> t -> t
 
 
-(** [up delta t] *)
+(** [up delta t]: increases all free variables in [t] by [delta] *)
 val up: int -> t -> t
 
+(** [up1 t]: increases all free variable in [t] by 1 *)
 val up1: t -> t
 
 (** [down_from delta start t] *)

--- a/ocaml/core/term.mli
+++ b/ocaml/core/term.mli
@@ -184,21 +184,33 @@ val map: (int -> int) -> t -> t
 
 
 
-(** [up_from start delta t]: increases all free variables >= [start] in [t] by [delta] *)
+(** [up_from start delta t]: increases all free variables >= [start] in [t] by [delta] 
+    
+    {e requires}: [0 <= delta]
+ *)
 val up_from: int -> int -> t -> t
 
 
-(** [up delta t]: increases all free variables in [t] by [delta] *)
+(** [up delta t]: increases all free variables in [t] by [delta]
+    
+    {e requires}: [0 <= delta]
+ *)
 val up: int -> t -> t
 
 (** [up1 t]: increases all free variable in [t] by 1 *)
 val up1: t -> t
 
-(** [down_from start delta t] *)
+(** [down_from start delta t]: decreases all free variables >= [start] in [t] by [delta] if possible. Returns [None] it there is a free variable in [t] with index [i < delta].
+
+    {e requires}: [0 <= delta]
+ *)
 val down_from: int -> int -> t -> t option
 
 
-(** [down delta t] *)
+(** [down delta t]: decreases all free variables in [t] by [delta] if possible. Returns [None] if there is a free variable in [t] with index [i < delta].
+
+    {e requires}: [0 <= delta]
+ *)
 val down: int -> t -> t option
 
 


### PR DESCRIPTION
I'm not completely satisfied with the layout of the comments. Ocamldoc has the tag `@return`, which formats the result of a function in a nice way. Maybe it would be good to have something like that also for pre- and postconditions?

I think we should decide on a common way do document the functions, before starting to document a lot of functions (and then change the layout afterwards...).